### PR TITLE
implemented media and mouse bindings

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -4,4 +4,5 @@ import "fmt"
 
 var (
 	ErrTypeMixing = fmt.Errorf("error cannot mix keyboard and mouse in a macro")
+	ErrUnsupported = fmt.Errorf("Unsupported Operation")
 )

--- a/keycodes.go
+++ b/keycodes.go
@@ -180,11 +180,11 @@ const (
 // 03 01 12 cd 00 00 00
 const (
 	PLAY   Mediacode = 0xcd
-	PREV             = 0xb6
-	NEXT             = 0xb5
-	MUTE             = 0xe2
-	VOL_UP           = 0xe9
-	VOL_DN           = 0xea
+	PREV   Mediacode = 0xb6
+	NEXT   Mediacode = 0xb5
+	MUTE   Mediacode = 0xe2
+	VOL_UP Mediacode = 0xe9
+	VOL_DN Mediacode = 0xea
 )
 
 // 03 01 13 04 00 00 00
@@ -199,6 +199,6 @@ const (
 // magic key layer len seq ?? code mod
 const (
 	MS_WL      Wheelcode = 0x00
-	MS_WL_UP             = 0x01
-	MS_WL_DOWN           = 0xff
+	MS_WL_UP   Wheelcode = 0x01
+	MS_WL_DOWN Wheelcode = 0xff
 )

--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ func main() {
 
 	kbd.BindMapping(MapKeys(Custom))
 	fmt.Println("done!")
+	os.Exit(0)
 }
 
 func SelectInterface() hid.DeviceInfo {


### PR DESCRIPTION
I've implemented different methods to write the proper binding messages for media key and mouse macros.
I am not certain if it's done correctly but I have tested it with a 6 key 1 rotary mini keyboard and it seems to work.
The data is constructed as indicated in the comments that have been written by @achushu .

fixes #2 
